### PR TITLE
Should use pathname instead of path, since path can also contain query string

### DIFF
--- a/lib/parse-database-url.js
+++ b/lib/parse-database-url.js
@@ -28,19 +28,19 @@ module.exports = function (databaseUrl) {
 
   if (config.driver === "sqlite3") {
     if (parsedUrl.hostname) {
-      if (parsedUrl.path) {
+      if (parsedUrl.pathname) {
         // Relative path.
-        config.filename = parsedUrl.hostname + parsedUrl.path;
+        config.filename = parsedUrl.hostname + parsedUrl.pathname;
       } else {
         // Just a filename.
         config.filename = parsedUrl.hostname;
       }
     } else {
       // Absolute path.
-      config.filename = parsedUrl.path;
+      config.filename = parsedUrl.pathname;
     }
   } else {
-    config.database = parsedUrl.path.replace(/^\//, "").replace(/\/$/, "");
+    config.database = parsedUrl.pathname.replace(/^\//, "").replace(/\/$/, "");
 
     if (parsedUrl.hostname) config.host = parsedUrl.hostname;
     if (parsedUrl.port) config.port = parsedUrl.port;


### PR DESCRIPTION
Should use pathname instead of path, since path can also contain query string.
