### PR TITLE
Correctly parse mysql2:// URLs

### DIFF
--- a/lib/parse-database-url.js
+++ b/lib/parse-database-url.js
@@ -16,8 +16,12 @@ module.exports = function (databaseUrl) {
   // Query parameters end up directly in the configuration.
   var config = querystring.parse(parsedUrl.query);
 
-  // The protocol coming from url.parse() has a trailing :
-  config.driver = (parsedUrl.protocol || "sqlite3:").replace(/\:$/, "");
+  config.driver = (parsedUrl.protocol || "sqlite3:")
+    // The protocol coming from url.parse() has a trailing :
+    .replace(/\:$/, "")
+
+    // Cloud Foundry will sometimes set a 'mysql2' scheme instead of 'mysql'
+    .replace(/^mysql2/, "mysql");
 
   // url.parse() produces an "auth" that looks like "user:password". No
   // individual fields, unfortunately.

--- a/test/parse_cases.json
+++ b/test/parse_cases.json
@@ -70,6 +70,18 @@
     }
   },
   {
+    "desc": "Cloud Foundry ClearDB connection string with mysql2 scheme",
+    "url": "mysql2://user:pass@host/database?reconnect=true",
+    "config": {
+      "driver": "mysql",
+      "user": "user",
+      "password": "pass",
+      "host": "host",
+      "database": "database",
+      "reconnect": "true"
+    }
+  },
+  {
       "desc": "Redis URL, which doesn't have a path (Issue #4)",
       "url": "redis://localhost:6379",
       "config": {


### PR DESCRIPTION
Cloud Foundry sets the DATABASE_URL env var with a 'mysql2://' scheme. This change copes with that, and allows easy use of Cloud Foundry e.g. run.pivotal.io.
