### PR TITLE
Support Mongo DB url with multiple hosts

### DIFF
--- a/lib/parse-database-url.js
+++ b/lib/parse-database-url.js
@@ -1,5 +1,6 @@
 var url = require("url");
 var querystring = require("querystring");
+var mongodbUri = require("mongodb-uri");
 
 /**
  * This is the exported function that parses database URLs.
@@ -19,6 +20,28 @@ module.exports = function (databaseUrl) {
   config.driver = (parsedUrl.protocol || "sqlite3:")
     // The protocol coming from url.parse() has a trailing :
     .replace(/\:$/, "")
+
+  // Mongo specific handling because `url` doesn't handle all variants of mongo url
+  if (config.driver == 'mongodb') {
+    // Use different package here to parse db url
+    var mongoConfig = mongodbUri.parse(databaseUrl);
+
+    // Mix and match config object to return the same object
+    config = {
+      'driver': config.driver,
+      'database': mongoConfig.database
+    };
+    config['host'] = mongoConfig.hosts.map(function(h) {
+      var s = h.host;
+      if (h.port) s += ":" + h.port;
+      return s;
+    });
+    if (mongoConfig.username) config['user'] = mongoConfig.username;
+    if (mongoConfig.password) config['password'] = mongoConfig.password;
+
+    return config;
+  }
+
 
   // Cloud Foundry will sometimes set a 'mysql2' scheme instead of 'mysql'.
   if (config.driver == "mysql2")

--- a/lib/parse-database-url.js
+++ b/lib/parse-database-url.js
@@ -31,11 +31,17 @@ module.exports = function (databaseUrl) {
       'driver': config.driver,
       'database': mongoConfig.database
     };
-    config['host'] = mongoConfig.hosts.map(function(h) {
-      var s = h.host;
-      if (h.port) s += ":" + h.port;
-      return s;
-    });
+    if (mongoConfig.hosts.length > 1) {
+      config['host'] = mongoConfig.hosts.map(function(h) {
+        var s = h.host;
+        if (h.port) s += ":" + h.port;
+        return s;
+      });
+    } else {
+      config['host'] = mongoConfig.hosts[0].host;
+      config['port'] = mongoConfig.hosts[0].port.toString();
+    }
+
     if (mongoConfig.username) config['user'] = mongoConfig.username;
     if (mongoConfig.password) config['password'] = mongoConfig.password;
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "node": ">= 0.6"
   },
   "dependencies": {
+    "mongodb-uri": "^0.9.7"
   },
   "devDependencies": {
     "chai": ">= 1.6.0",

--- a/test/parse_cases.json
+++ b/test/parse_cases.json
@@ -89,5 +89,14 @@
         "host": "localhost",
         "port": "6379"
       }
+  },
+  {
+      "desc": "Mongo URL with have replica set",
+      "url": "mongodb://localhost:27017,localhost:27018,localhost:27019/database",
+      "config": {
+        "driver": "mongodb",
+        "database": "database",
+        "host": ["localhost:27017", "localhost:27018", "localhost:27019"]
+      }
   }
 ]

--- a/test/parse_cases.json
+++ b/test/parse_cases.json
@@ -91,6 +91,16 @@
       }
   },
   {
+    "desc": "Mongo URL",
+    "url": "mongodb://localhost:27017/database",
+    "config": {
+      "driver": "mongodb",
+      "database": "database",
+      "host": "localhost",
+      "port": "27017"
+    }
+  },
+  {
       "desc": "Mongo URL with have replica set",
       "url": "mongodb://localhost:27017,localhost:27018,localhost:27019/database",
       "config": {


### PR DESCRIPTION
Node's url module doesn't know how to parse url such as:
`mongodb://localhost:27017,localhost:27018,localhost:271019`
That's why I've added specific case support for this.

This refer to https://github.com/db-migrate/node-db-migrate/issues/330
And https://github.com/pwnall/node-parse-database-url/issues/6
